### PR TITLE
Fixed Tor authentication. Improved error handling. Fix for PHP < 5.5.23 and PHP < 5.6.7.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,10 +4,12 @@ namespace GuzzleTor;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\RequestInterface;
 
-const TOR_OK = 250;
+defined('CURLPROXY_SOCKS5_HOSTNAME') or define('CURLPROXY_SOCKS5_HOSTNAME', 7);
 
 class Middleware
 {
+    const TOR_OK = 250;
+
     /**
      * This middleware allows to use Tor client as a proxy
      *
@@ -60,14 +62,14 @@ class Middleware
         fputs($socket, "AUTHENTICATE $password\r\n");
         $response = fread($socket, 1024);
         $code = explode(' ', $response, 2)[0];
-        if (TOR_OK != $code) {
+        if (self::TOR_OK != $code) {
             throw new TorNewIdentityException("Could not authenticate on Tor client");
         }
 
         fputs($socket, "signal NEWNYM\r\n");
         $response = fread($socket, 1024);
         $code = explode(' ', $response, 2)[0];
-        if (TOR_OK != $code) {
+        if (self::TOR_OK != $code) {
             throw new TorNewIdentityException("Could not get new identity");
         }
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -57,18 +57,18 @@ class Middleware
             throw new TorNewIdentityException("Could not connect to Tor client on $torControl: $errNo $errStr");
         }
 
-        fputs($socket, "AUTHENTICATE $password\r\n");
+        fputs($socket, "AUTHENTICATE \"$password\"\r\n");
         $response = fread($socket, 1024);
         $code = explode(' ', $response, 2)[0];
         if (TOR_OK != $code) {
-            throw new TorNewIdentityException("Could not authenticate on Tor client");
+            throw new TorNewIdentityException("Could not authenticate on Tor client, response: $response");
         }
 
         fputs($socket, "signal NEWNYM\r\n");
         $response = fread($socket, 1024);
         $code = explode(' ', $response, 2)[0];
         if (TOR_OK != $code) {
-            throw new TorNewIdentityException("Could not get new identity");
+            throw new TorNewIdentityException("Could not get new identity, response: $response");
         }
 
         fclose($socket);


### PR DESCRIPTION
1. Define CURLPROXY_SOCKS5_HOSTNAME for PHP < 5.5.23 and PHP < 5.6.7. TOR_OK moved to class Middleware.
   I encountered with issue on Ubuntu 14.04, PHP 5.5.9 and curl 7.35.0. CURLPROXY_SOCKS5_HOSTNAME is not defined in PHP < 5.5.23 and PHP < 5.6.7 http://php.net/manual/en/curl.constants.php, but if we will define it then it works correct with curl.
2. Fixed Tor authentication. Improved error handling.
   Without this fix I get error message from Tor client "551 Invalid quoted string. You need to put the password in double quotes."
