### PR TITLE
prevent debug message on cli

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -31,7 +31,7 @@ class Middleware
                     ]
                 ], $options);
 
-                if (@$options['tor_new_identity']) {
+                if (array_key_exists('tor_new_identity', $options) && $options['tor_new_identity']) {
                     try {
                         self::requireNewTorIdentity($torControl, $options);
                     } catch (GuzzleException $e) {


### PR DESCRIPTION
Prevent this kind of message
php.DEBUG: Notice: Undefined index: tor_new_identity {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\SilencedErrorContext: {\"severity\":8,\"file\":\"/XXXXX/vendor/megahertz/guzzle-tor/src/Middleware.php\",\"line\":34})"}

using cli command with -vvv